### PR TITLE
added parseInt to convert user input

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ Let's take a look at the implementation.
 Add the following function to the `Minutes` component:
 ```jsx
 const handleInputChange = event => {
-  setMinutes(event.target.value)
+  setMinutes(parseInt(event.target.value))
 }
 ```
 


### PR DESCRIPTION
Updated a code snippet in the readME -- without parseInt, a string of a number is passed into state instead of an integer. This breaks the click to add/subtract functionality.